### PR TITLE
Compatibility with future rstan

### DIFF
--- a/tmbstan/DESCRIPTION
+++ b/tmbstan/DESCRIPTION
@@ -9,8 +9,8 @@ Description: Enables all 'rstan' functionality for a 'TMB' model object, in part
 Imports: methods, Rcpp
 Depends:
     rstan, TMB (>= 1.7.12)
-LinkingTo: StanHeaders, rstan, BH, Rcpp, RcppEigen, TMB
+LinkingTo: StanHeaders, rstan, BH, Rcpp, RcppEigen, TMB, RcppParallel
 License: GPL (>= 3)
 BugReports: https://github.com/kaskr/tmbstan/issues
 NeedsCompilation: yes
-RoxygenNote: 5.0.1
+RoxygenNote: 7.1.2

--- a/tmbstan/src/Makevars
+++ b/tmbstan/src/Makevars
@@ -1,3 +1,7 @@
 STANHEADERS_SRC = `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders"`
-PKG_CPPFLAGS = -I"$(STANHEADERS_SRC)" -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_NO_CXX11_RVALUE_REFERENCES
+
+STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
+PKG_CPPFLAGS = -I"$(STANHEADERS_SRC)" -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_NO_CXX11_RVALUE_REFERENCES  $(STANC_FLAGS)
+PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
+PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 CXX_STD = CXX14


### PR DESCRIPTION
Hi,

This PR adds the changes to build flags that are needed for compatibility with the upcoming release of rstan. These changes include adding compiler & linker flags needed for working with `StanHeaders` >= 2.26, namely the addition of the TBB (`RcppParallel`).

Additionally, this PR adds a compiler flag to your `Makevars` files which is needed for compatibility with the upcoming version of `rstan`:  `-DUSE_STANC3`

The Stan-to-c++ transpiler (`stanc`) was refactored after 2.21, and so different c++ is used in the new `rstan` package (>= 2.26). Because of this, the flag `-DUSE_STANC3` needs to be added when a stan model is being run using the new rstan package (and the new stanc implementation).


Feel free to let me know if you need any more info.

Thanks!
Andrew