### PR TITLE
Remove one define upsetting Boost 1.78.0

### DIFF
--- a/tmbstan/src/Makevars
+++ b/tmbstan/src/Makevars
@@ -1,7 +1,7 @@
 STANHEADERS_SRC = `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders"`
 
 STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
-PKG_CPPFLAGS = -I"$(STANHEADERS_SRC)" -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_NO_CXX11_RVALUE_REFERENCES  $(STANC_FLAGS)
+PKG_CPPFLAGS = -I"$(STANHEADERS_SRC)" -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG $(STANC_FLAGS)
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 CXX_STD = CXX14


### PR DESCRIPTION
Dear tmbstan tean,

As discussed in https://github.com/eddelbuettel/bh/issues/80 package BH would like to update to Boost 1.78.  This is mostly smooth sailing but package `tmbstan` throws the truly bizarre error below.  That is arguably a Boost error getting confused about its own define ... but alas simply removing it works.   

The PR does that.  You should be safe with the PR as long as R builds are concerned as we'd always have BH to provide that 'one' version of Boost, otherweise you could to be fancier and inject the define for older versions. 

It would be great if you could update `tmpstan` as we will likely ship a new BH soon.  Let me know if you have questions.

Thanks,  Dirk

```
In file included from /usr/local/lib/R/site-library/BH/include/boost/math/constants/constants.hpp:11,
                 from /home/dirk/tmp/lib/StanHeaders/include/stan/math/prim/scal/fun/constants.hpp:6,
                 from /home/dirk/tmp/lib/StanHeaders/include/stan/math/rev/core/operator_unary_plus.hpp:7,
                 from /home/dirk/tmp/lib/StanHeaders/include/stan/math/rev/core.hpp:38,
                 from /home/dirk/tmp/lib/StanHeaders/include/stan/math/rev/mat.hpp:6,
                 from /home/dirk/tmp/lib/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4,
                 from /home/dirk/tmp/lib/StanHeaders/include/src/stan/model/test_gradients.hpp:7,
                 from /home/dirk/tmp/lib/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10,
                 from /home/dirk/tmp/lib/rstan/include/rstan/stan_fit.hpp:35,                                                                                                                                      
                 from /home/dirk/tmp/lib/rstan/include/rstan/rstaninc.hpp:4,
                 from include/model.hpp:2,                                                               
                 from Modules.cpp:3:    
/usr/local/lib/R/site-library/BH/include/boost/math/tools/cxx03_warn.hpp:92:2: error: #error Support for C++03 has been removed. The minimum requirement for this library is fully compliant C++11.
   92 | #error Support for C++03 has been removed. The minimum requirement for this library is fully compliant C++11.
      |  ^~~~~                                      
make: *** [/usr/lib/R/etc/Makeconf:177: Modules.o] Error 1                                                                                                                                                         
ERROR: compilation failed for package ‘tmbstan’
```