### PR TITLE
Update reserved Stan keyword

### DIFF
--- a/tmbstan/inst/model226.stan
+++ b/tmbstan/inst/model226.stan
@@ -1,7 +1,7 @@
 functions {
-  vector make_bounds(vector bound_in, int N, int upper) {
+  vector make_bounds(vector bound_in, int N, int is_upper) {
     if (num_elements(bound_in) == 0) {
-      real bound = (upper == 1 ? positive_infinity() : negative_infinity());
+      real bound = (is_upper == 1 ? positive_infinity() : negative_infinity());
       return rep_vector(bound, N);
     } else {
       return bound_in;


### PR DESCRIPTION
When checking packages against a future version of Stan, I've found that your Stan model is using a reserved keyword which will cause an error in a future version of `rstan` (I introduced this one, sorry!), this PR updates your syntax to avoid this.

There's also no pressure on getting this included in a CRAN release, this won't be an issue for a while